### PR TITLE
ConvLayerNorm returns None?

### DIFF
--- a/encodec/modules/norm.py
+++ b/encodec/modules/norm.py
@@ -25,4 +25,4 @@ class ConvLayerNorm(nn.LayerNorm):
         x = einops.rearrange(x, 'b ... t -> b t ...')
         x = super().forward(x)
         x = einops.rearrange(x, 'b t ... -> b ... t')
-        return
+        return x


### PR DESCRIPTION
Hi authors, thank you for open-sourcing this nice work.

I noticed there is no return value in this class.

Shouldn't it be `return x` or did I miss something?

I made a quick PR for it.