### PR TITLE
sync_buffer function in distrib.py has a typo?

### DIFF
--- a/encodec/distrib.py
+++ b/encodec/distrib.py
@@ -87,7 +87,7 @@ def sync_buffer(buffers, average=True):
     for buffer, handle in handles:
         handle.wait()
         if average:
-            buffer.data /= world_size
+            buffer.data /= world_size()
 
 
 def sync_grad(params):


### PR DESCRIPTION
Hi thanks for share this code,

In the last line of `sync_buffer` function, should `world_size` be `world_size()`?